### PR TITLE
Add asynchronous FTP CLI with interactive shell

### DIFF
--- a/ftp-cli/config.py
+++ b/ftp-cli/config.py
@@ -1,0 +1,109 @@
+"""Configuration management for FTP CLI profiles."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from rich.console import Console
+
+
+console = Console()
+
+
+DEFAULT_CONFIG_PATH = Path.home() / ".ftpcli" / "config.json"
+
+
+@dataclass
+class ServerProfile:
+    """Represents a saved FTP server profile."""
+
+    name: str
+    host: str
+    user: str
+    password: str
+    port: int = 21
+    secure: bool = False
+
+    @classmethod
+    def from_dict(cls, name: str, data: Dict[str, object]) -> "ServerProfile":
+        return cls(
+            name=name,
+            host=str(data.get("host", "")),
+            user=str(data.get("user", "")),
+            password=str(data.get("password", "")),
+            port=int(data.get("port", 21)),
+            secure=bool(data.get("secure", False)),
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        data = asdict(self)
+        data.pop("name", None)
+        return data
+
+
+class ConfigManager:
+    """Handles loading and storing FTP server profiles."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_CONFIG_PATH
+        self._ensure_config_file()
+        self._profiles: Dict[str, ServerProfile] = {}
+        self._load()
+
+    def _ensure_config_file(self) -> None:
+        if not self.path.parent.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.path.write_text(json.dumps({"servers": {}}), encoding="utf-8")
+
+    def _load(self) -> None:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            console.print(
+                f"[yellow]Warning:[/] configuration file at {self.path} is corrupted. Resetting."
+            )
+            data = {"servers": {}}
+
+        servers = data.get("servers", {})
+        self._profiles = {
+            name: ServerProfile.from_dict(name, value) for name, value in servers.items()
+        }
+
+    def _save(self) -> None:
+        payload = {"servers": {name: profile.to_dict() for name, profile in self._profiles.items()}}
+        self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    def add_server(
+        self,
+        name: str,
+        host: str,
+        user: str,
+        password: str,
+        *,
+        port: int = 21,
+        secure: bool = False,
+    ) -> None:
+        profile = ServerProfile(name=name, host=host, user=user, password=password, port=port, secure=secure)
+        self._profiles[name] = profile
+        self._save()
+
+    def get_server(self, name: str) -> Optional[ServerProfile]:
+        return self._profiles.get(name)
+
+    def delete_server(self, name: str) -> bool:
+        if name in self._profiles:
+            del self._profiles[name]
+            self._save()
+            return True
+        return False
+
+    def list_servers(self) -> Iterable[ServerProfile]:
+        return sorted(self._profiles.values(), key=lambda profile: profile.name.lower())
+
+
+__all__ = ["ConfigManager", "ServerProfile", "DEFAULT_CONFIG_PATH"]
+

--- a/ftp-cli/ftp_cli.py
+++ b/ftp-cli/ftp_cli.py
@@ -1,0 +1,92 @@
+"""Typer entrypoint for the FTP CLI application."""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from config import ConfigManager, ServerProfile
+from shell import FTPShell
+
+
+app = typer.Typer(help="Modern FTP client with saved profiles and interactive shell.")
+console = Console()
+config = ConfigManager()
+
+
+def _print_server_table(profiles) -> None:
+    table = Table(title="Saved FTP Servers")
+    table.add_column("Name", style="bold")
+    table.add_column("Host")
+    table.add_column("User")
+    table.add_column("Port", justify="right")
+    table.add_column("Secure", justify="center")
+
+    for profile in profiles:
+        table.add_row(
+            profile.name,
+            profile.host,
+            profile.user,
+            str(profile.port),
+            "🔒" if profile.secure else "",
+        )
+    console.print(table)
+
+
+@app.command()
+def add_server(
+    name: str = typer.Argument(..., help="Name for the server profile."),
+    host: str = typer.Option(..., "--host", prompt=True, help="FTP host."),
+    user: str = typer.Option(..., "--user", prompt=True, help="Username."),
+    password: str = typer.Option(..., "--password", prompt=True, hide_input=True, help="Password."),
+    port: int = typer.Option(21, "--port", help="FTP port."),
+    secure: bool = typer.Option(False, "--secure", help="Use implicit TLS."),
+) -> None:
+    """Save a new FTP server profile."""
+
+    config.add_server(name, host, user, password, port=port, secure=secure)
+    console.print(f"[green]Server '{name}' saved.[/green]")
+
+
+@app.command()
+def list_servers() -> None:
+    """List saved FTP server profiles."""
+
+    profiles = list(config.list_servers())
+    if not profiles:
+        console.print("[yellow]No servers saved yet.[/yellow]")
+        return
+    _print_server_table(profiles)
+
+
+@app.command()
+def remove_server(name: str = typer.Argument(..., help="Name of the server profile.")) -> None:
+    """Remove a saved FTP server profile."""
+
+    if config.delete_server(name):
+        console.print(f"[green]Removed server '{name}'.[/green]")
+    else:
+        console.print(f"[red]Server '{name}' not found.[/red]")
+
+
+def _ensure_server(name: str) -> ServerProfile:
+    profile = config.get_server(name)
+    if not profile:
+        console.print(f"[red]Server '{name}' not found.[/red]")
+        raise typer.Exit(code=1)
+    return profile
+
+
+@app.command()
+def connect(name: str = typer.Argument(..., help="Server profile to connect to.")) -> None:
+    """Connect to a saved server and enter interactive shell."""
+
+    profile = _ensure_server(name)
+    shell = FTPShell(profile)
+    shell.cmdloop()
+
+
+if __name__ == "__main__":
+    app()
+

--- a/ftp-cli/ftp_client.py
+++ b/ftp-cli/ftp_client.py
@@ -1,0 +1,244 @@
+"""Async FTP client wrapper built on top of aioftp."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from queue import Queue
+from threading import Thread
+from typing import Any, Coroutine, Iterable, List, Optional, TypeVar
+
+import aioftp
+from rich.console import Console
+from rich.table import Table
+
+from config import ServerProfile
+from utils.progress import run_progress_monitor
+
+
+console = Console()
+
+
+@dataclass
+class DirectoryEntry:
+    name: str
+    is_dir: bool
+    size: int | None = None
+    modified: str | None = None
+
+
+T = TypeVar("T")
+
+
+class FTPClient:
+    """High-level FTP client with progress reporting."""
+
+    def __init__(self, profile: ServerProfile) -> None:
+        self.profile = profile
+        self._loop = asyncio.new_event_loop()
+        self._thread = Thread(target=self._start_loop, daemon=True)
+        self._thread.start()
+        self._client: Optional[aioftp.Client] = None
+        self._connected = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _start_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def _submit(self, coro: Coroutine[Any, Any, T]) -> asyncio.Future:
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+
+    async def _ensure_client(self) -> aioftp.Client:
+        if self._client is None:
+            self._client = aioftp.Client()
+        return self._client
+
+    async def _connect(self) -> None:
+        client = await self._ensure_client()
+        await client.connect(self.profile.host, self.profile.port, ssl=self.profile.secure or None)
+        await client.login(self.profile.user, self.profile.password)
+        self._connected = True
+
+    async def _disconnect(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.quit()
+            finally:
+                await self._client.close()
+        self._client = None
+        self._connected = False
+
+    async def _pwd(self) -> str:
+        if self._client is None:
+            return "/"
+        path = await self._client.get_current_directory()
+        return str(path)
+
+    async def _cwd(self, path: str) -> str:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+        await self._client.change_directory(path)
+        return await self._pwd()
+
+    async def _list(self, path: Optional[str]) -> List[DirectoryEntry]:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+        entries: List[DirectoryEntry] = []
+        async for item_path, info in self._client.list(path or None):
+            # info can be dict-like; fall back gracefully
+            is_dir = str(info.get("type", "")).lower() == "dir"
+            size_raw = info.get("size")
+            try:
+                size = int(size_raw) if size_raw is not None else None
+            except (TypeError, ValueError):
+                size = None
+            modified = info.get("modify")
+            entries.append(
+                DirectoryEntry(name=item_path.name, is_dir=is_dir, size=size, modified=modified)
+            )
+        return entries
+
+    async def _size(self, remote_path: str) -> int:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+        stat = await self._client.stat(remote_path)
+        size = getattr(stat, "size", None)
+        if isinstance(size, (int, float)):
+            return int(size)
+        if size is None:
+            return 0
+        try:
+            return int(size)
+        except (TypeError, ValueError):
+            return 0
+
+    async def _download(self, remote_path: str, local_path: Path, queue: Queue) -> None:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        async with self._client.download_stream(remote_path) as stream:
+            with local_path.open("wb") as buffer:
+                async for block in stream.iter_by_block(65536):
+                    buffer.write(block)
+                    queue.put(len(block))
+
+        queue.put(None)
+
+    async def _upload(self, local_path: Path, remote_path: str, queue: Queue) -> None:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+
+        async with self._client.upload_stream(remote_path) as stream:
+            with local_path.open("rb") as buffer:
+                while True:
+                    chunk = buffer.read(65536)
+                    if not chunk:
+                        break
+                    await stream.write(chunk)
+                    queue.put(len(chunk))
+
+        queue.put(None)
+
+    async def _mkdir(self, path: str) -> None:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+        await self._client.make_directory(path)
+
+    async def _remove(self, path: str) -> None:
+        if self._client is None:
+            raise RuntimeError("Client not connected")
+        await self._client.remove_file(path)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def connect(self) -> None:
+        future = self._submit(self._connect())
+        future.result()
+
+    def disconnect(self) -> None:
+        future = self._submit(self._disconnect())
+        future.result()
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    def pwd(self) -> str:
+        future = self._submit(self._pwd())
+        return future.result()
+
+    def cd(self, path: str) -> str:
+        future = self._submit(self._cwd(path))
+        return future.result()
+
+    def list_dir(self, path: Optional[str] = None) -> Iterable[DirectoryEntry]:
+        future = self._submit(self._list(path))
+        return future.result()
+
+    def download(self, remote_path: str, local_path: str) -> None:
+        target = Path(local_path)
+        size_future = self._submit(self._size(remote_path))
+        total = size_future.result()
+        queue: Queue[int | None] = Queue()
+        transfer_future = self._submit(self._download(remote_path, target, queue))
+        run_progress_monitor(
+            description=f"Downloading {remote_path}",
+            total=total,
+            queue=queue,
+            future=transfer_future,
+        )
+
+    def upload(self, local_path: str, remote_path: str) -> None:
+        source = Path(local_path)
+        if not source.exists():
+            raise FileNotFoundError(local_path)
+        total = source.stat().st_size
+        queue: Queue[int | None] = Queue()
+        transfer_future = self._submit(self._upload(source, remote_path, queue))
+        run_progress_monitor(
+            description=f"Uploading {source.name}",
+            total=total,
+            queue=queue,
+            future=transfer_future,
+        )
+
+    def show_directory_table(self, path: Optional[str] = None) -> None:
+        entries = self.list_dir(path)
+        table = Table(title=f"Directory listing for {path or self.pwd()}")
+        table.add_column("Name", overflow="fold")
+        table.add_column("Type")
+        table.add_column("Size", justify="right")
+        table.add_column("Modified", overflow="fold")
+        for entry in entries:
+            table.add_row(
+                entry.name,
+                "dir" if entry.is_dir else "file",
+                f"{entry.size:,}" if entry.size else "-",
+                entry.modified or "-",
+            )
+        console.print(table)
+
+    def mkdir(self, path: str) -> None:
+        future = self._submit(self._mkdir(path))
+        future.result()
+
+    def remove_file(self, path: str) -> None:
+        future = self._submit(self._remove(path))
+        future.result()
+
+    def close(self) -> None:
+        if self._connected:
+            self.disconnect()
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=1)
+
+
+__all__ = ["FTPClient", "DirectoryEntry"]
+

--- a/ftp-cli/shell.py
+++ b/ftp-cli/shell.py
@@ -1,0 +1,158 @@
+"""Interactive FTP shell built on cmd2."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import cmd2
+from rich.console import Console
+from rich.prompt import Prompt
+
+from config import ServerProfile
+from ftp_client import FTPClient
+
+
+console = Console()
+
+
+class FTPShell(cmd2.Cmd):
+    intro = "Welcome to FTP-CLI shell. Type 'help' to see available commands."
+    prompt = "ftp> "
+
+    def __init__(self, server: ServerProfile) -> None:
+        super().__init__(allow_cli_args=False)
+        self.server = server
+        self.ftp = FTPClient(server)
+        self.hidden_commands.append("py")  # hide python command for cleaner UX
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+    def preloop(self) -> None:
+        console.print(f"Connecting to [bold]{self.server.host}[/bold] as [green]{self.server.user}[/green]...")
+        try:
+            self.ftp.connect()
+            console.print("[green]Connected successfully![/green]")
+        except Exception as exc:  # pragma: no cover - surface failure
+            console.print(f"[red]Connection failed:[/] {exc}")
+            raise SystemExit(1)
+
+    def postloop(self) -> None:
+        if self.ftp.connected:
+            self.ftp.close()
+        console.print("[cyan]Disconnected. Goodbye![/cyan]")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_argument(self, argument: str, message: str) -> str:
+        if argument:
+            return argument
+        return Prompt.ask(message)
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+    def do_pwd(self, _: cmd2.Statement) -> None:
+        """Show current working directory."""
+
+        console.print(f"[bold]{self.ftp.pwd()}[/bold]")
+
+    def do_cd(self, statement: cmd2.Statement) -> None:
+        """Change remote directory."""
+
+        path = self._ensure_argument(statement.arg, "Remote path")
+        try:
+            new_path = self.ftp.cd(path)
+            console.print(f"[green]Changed directory to[/green] [bold]{new_path}[/bold]")
+        except Exception as exc:
+            console.print(f"[red]Failed to change directory:[/] {exc}")
+
+    def do_ls(self, statement: cmd2.Statement) -> None:
+        """List files in the current or provided directory."""
+
+        path = statement.arg.strip() or None
+        try:
+            self.ftp.show_directory_table(path)
+        except Exception as exc:
+            console.print(f"[red]Failed to list directory:[/] {exc}")
+
+    def do_get(self, statement: cmd2.Statement) -> None:
+        """Download a file from the server."""
+
+        parts = statement.arg.split()
+        if not parts:
+            remote_path = Prompt.ask("Remote file path")
+            local_path = Prompt.ask("Local destination", default=Path(remote_path).name)
+        elif len(parts) == 1:
+            remote_path = parts[0]
+            local_path = Path(parts[0]).name
+        else:
+            remote_path, local_path = parts[0], parts[1]
+
+        try:
+            self.ftp.download(remote_path, local_path)
+            console.print(f"[green]Downloaded[/green] {remote_path} → {local_path}")
+        except Exception as exc:
+            console.print(f"[red]Download failed:[/] {exc}")
+
+    def do_put(self, statement: cmd2.Statement) -> None:
+        """Upload a file to the server."""
+
+        parts = statement.arg.split()
+        if not parts:
+            local_path = Prompt.ask("Local file path")
+            remote_path = Prompt.ask("Remote destination", default=Path(local_path).name)
+        elif len(parts) == 1:
+            local_path = parts[0]
+            remote_path = Path(parts[0]).name
+        else:
+            local_path, remote_path = parts[0], parts[1]
+
+        try:
+            self.ftp.upload(local_path, remote_path)
+            console.print(f"[green]Uploaded[/green] {local_path} → {remote_path}")
+        except Exception as exc:
+            console.print(f"[red]Upload failed:[/] {exc}")
+
+    def do_mkdir(self, statement: cmd2.Statement) -> None:
+        """Create a directory on the server."""
+
+        path = self._ensure_argument(statement.arg, "Directory name")
+        try:
+            self.ftp.mkdir(path)
+            console.print(f"[green]Created directory[/green] {path}")
+        except Exception as exc:
+            console.print(f"[red]Failed to create directory:[/] {exc}")
+
+    def do_rm(self, statement: cmd2.Statement) -> None:
+        """Delete a file on the server."""
+
+        path = self._ensure_argument(statement.arg, "File to remove")
+        try:
+            self.ftp.remove_file(path)
+            console.print(f"[green]Removed[/green] {path}")
+        except Exception as exc:
+            console.print(f"[red]Failed to remove file:[/] {exc}")
+
+    def do_disconnect(self, _: cmd2.Statement) -> bool:
+        """Disconnect from the FTP server and exit the shell."""
+
+        self.close()
+        return True
+
+    def do_exit(self, statement: cmd2.Statement) -> bool:  # pragma: no cover - alias
+        return self.do_disconnect(statement)
+
+    def do_quit(self, statement: cmd2.Statement) -> bool:  # pragma: no cover - alias
+        return self.do_disconnect(statement)
+
+    def close(self) -> None:
+        if self.ftp.connected:
+            try:
+                self.ftp.close()
+            except Exception as exc:  # pragma: no cover - best effort cleanup
+                console.print(f"[yellow]Warning:[/] Failed to close connection cleanly: {exc}")
+
+
+__all__ = ["FTPShell"]
+

--- a/ftp-cli/utils/__init__.py
+++ b/ftp-cli/utils/__init__.py
@@ -1,0 +1,2 @@
+"""Utility helpers for the FTP CLI application."""
+

--- a/ftp-cli/utils/progress.py
+++ b/ftp-cli/utils/progress.py
@@ -1,0 +1,67 @@
+"""Progress bar utilities built with Rich."""
+
+from __future__ import annotations
+
+from queue import Empty, Queue
+from typing import Optional
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+    TransferSpeedColumn,
+)
+
+
+console = Console()
+
+
+def _create_progress() -> Progress:
+    return Progress(
+        TextColumn("{task.description}"),
+        BarColumn(bar_width=None),
+        TextColumn("{task.completed}/{task.total}"),
+        TransferSpeedColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+    )
+
+
+def run_progress_monitor(
+    *,
+    description: str,
+    total: Optional[int],
+    queue: Queue,
+    future,
+) -> None:
+    """Render a progress bar while monitoring a queue for updates."""
+
+    if total in (0, None):
+        total = None
+
+    with _create_progress() as progress:
+        task_id: TaskID = progress.add_task(description, total=total)
+        while True:
+            try:
+                update = queue.get(timeout=0.1)
+                if update is None:
+                    progress.refresh()
+                    break
+                progress.advance(task_id, update)
+            except Empty:
+                pass
+
+            if future.done():
+                break
+
+        # Wait for the transfer to finish and surface exceptions
+        future.result()
+
+
+__all__ = ["run_progress_monitor"]
+


### PR DESCRIPTION
## Summary
- add Typer-based CLI for managing FTP profiles and launching the interactive shell
- implement configuration manager for storing saved FTP connections in ~/.ftpcli/config.json
- build aioftp-powered client, Rich progress helpers, and cmd2 shell for interactive transfers

## Testing
- python -m compileall ftp-cli

------
https://chatgpt.com/codex/tasks/task_e_68d898b439d4832cbea169f5726ae8d0